### PR TITLE
Configure nginx for frontend

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -21,5 +21,6 @@ RUN npm run build
 FROM nginx:1.21
 
 COPY --from=build-stage /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
 
 CMD nginx -g 'daemon off;'

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,49 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
+
+        error_page  404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+        }
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,6 +47,8 @@ services:
       - "8004:80"
     environment:
       REACT_APP_API_URL: ${REACT_APP_API_URL}
+    volumes:
+      - ./client/nginx.conf:/etc/nginx/nginx.conf
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:3000" ]
       interval: 30s


### PR DESCRIPTION
Add nginx configuration and update Dockerfile and docker-compose.yaml to use nginx for serving the frontend.

* **Dockerfile**:
  - Add a line to copy `nginx.conf` to `/etc/nginx/nginx.conf`.

* **nginx.conf**:
  - Create a new nginx configuration file with server settings.
  - Set the server to listen on port 80.
  - Configure the root directory to `/usr/share/nginx/html`.
  - Add a location block to handle all requests and serve `index.html`.

* **docker-compose.yaml**:
  - Update the `frontend` service to use the new `nginx.conf` file.
  - Add a volume to mount the `nginx.conf` file to `/etc/nginx/nginx.conf`.

